### PR TITLE
cgroups: Remount cgroup root fs read/write if it is read-only

### DIFF
--- a/devlib/module/cgroups.py
+++ b/devlib/module/cgroups.py
@@ -58,6 +58,10 @@ class Controller(object):
                     if fs.device == self.mount_name
                 ][0]
         else:
+            # Check if cgroup root is mounted ro, if it is remount rw
+            fs = [e for e in mounted if e.mount_point == mount_root ][0]
+            if 'ro' in fs.options:
+                target.execute('mount -o remount rw {}'.format(mount_root))
             # Mount the controller if not already in use
             self.mount_point = target.path.join(mount_root, self.mount_name)
             target.execute('mkdir -p {} 2>/dev/null'\

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -75,7 +75,7 @@ class FtraceCollector(TraceCollector):
         self.start_time = None
         self.stop_time = None
         self.event_string = _build_trace_events(self.events)
-        self.function_string = _build_trace_functions(self.functions)
+        self.function_string = None
         self._reset_needed = True
 
         # Setup tracing paths
@@ -111,9 +111,13 @@ class FtraceCollector(TraceCollector):
             # Validate required functions to be traced
             available_functions = self.target.execute(
                     'cat {}'.format(self.available_functions_file)).splitlines()
+            selected_functions = []
             for function in self.functions:
                 if function not in available_functions:
-                    raise TargetError('Function [{}] not available for filtering'.format(function))
+                    self.target.logger.warning('Function [{}] not available for profiling'.format(function))
+                else:
+                    selected_functions.append(function)
+            self.function_string = _build_trace_functions(selected_functions)
 
     def reset(self):
         if self.buffer_size:

--- a/devlib/trace/ftrace.py
+++ b/devlib/trace/ftrace.py
@@ -125,9 +125,9 @@ class FtraceCollector(TraceCollector):
         self.start_time = time.time()
         if self._reset_needed:
             self.reset()
+        self.target.execute('{} start {}'.format(self.target_binary, self.event_string), as_root=True)
         if self.automark:
             self.mark_start()
-        self.target.execute('{} start {}'.format(self.target_binary, self.event_string), as_root=True)
         if 'cpufreq' in self.target.modules:
             self.logger.debug('Trace CPUFreq frequencies')
             self.target.cpufreq.trace_frequencies()


### PR DESCRIPTION
In case the cgroup root fs is mounted read-only, the cgroups
used by Lisa cannot be mounted.

Issue was detected on Hikey board with Linaro fs.

$ cat /etc/issue
Debian GNU/Linux 8 \n \l

Signed-off-by: Dietmar Eggemann dietmar.eggemann@arm.com
